### PR TITLE
Format team message for WhatsApp

### DIFF
--- a/api/webhook.js
+++ b/api/webhook.js
@@ -59,9 +59,22 @@ export default async function handler(req, res) {
       // Shuffle + split to A/B/C
       const { A, B, C } = makeTeams(names);
 
-      await sendText(WHATSAPP_TOKEN, PHONE_NUMBER_ID, from,
-        `✅ Teams generated:\n\nA: ${A.join(", ")}\nB: ${B.join(", ")}\nC: ${C.join(", ")}`
-      );
+      const replyText = [
+        'רביעי 20:20',
+        '',
+        '🔴🔴🔴',
+        ...A,
+        '',
+        '⚫️⚫️⚫️',
+        ...B,
+        '',
+        '⚪️⚪️⚪️',
+        ...C,
+        '',
+        'רביעי שמח!'
+      ].join('\n');
+
+      await sendText(WHATSAPP_TOKEN, PHONE_NUMBER_ID, from, replyText);
 
       return res.status(200).end();
     } catch (e) {


### PR DESCRIPTION
## Summary
- format generated teams with colored bullet icons and Hebrew headings
- avoid variable name collision when sending formatted message

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8326483208324a77070cbe32ac7e4