### PR TITLE
Remove refresh button from home and matchdays pages

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -630,7 +630,7 @@
         "description": "Remove the refresh button from the home page UI, which is currently located in the top-right corner next to the 'Create Matchday' button.",
         "details": "To remove the refresh button from the home page, locate the component or template file where the home page UI is defined. Identify the section of the code where the refresh button is rendered. This may involve searching for button elements or specific identifiers related to the refresh functionality. Once located, remove the HTML or JSX code responsible for rendering the refresh button. Ensure that any associated event handlers or state management logic related to the refresh button are also removed to prevent any potential errors or warnings. After removal, review the layout to ensure that the absence of the button does not affect the alignment or spacing of other UI elements. Consider updating any documentation or comments in the codebase that reference the refresh button to reflect its removal.",
         "testStrategy": "Verify that the refresh button is no longer visible on the home page by manually inspecting the UI. Check the browser console for any errors or warnings that might indicate leftover event handlers or state logic related to the refresh button. Ensure that the layout of the home page remains consistent and that other elements, such as the 'Create Matchday' button, are properly aligned. Conduct a code review to confirm that all references to the refresh button have been removed from the codebase.",
-        "status": "pending",
+        "status": "done",
         "dependencies": [
           14
         ],
@@ -640,7 +640,7 @@
     ],
     "metadata": {
       "created": "2025-09-20T12:23:50.420Z",
-      "updated": "2025-09-21T11:21:30.246Z",
+      "updated": "2025-09-21T11:39:54.583Z",
       "description": "Tasks for master context"
     }
   }

--- a/src/app/matchdays/page.tsx
+++ b/src/app/matchdays/page.tsx
@@ -47,7 +47,7 @@ export default function MatchdaysPage() {
   }, [supabase.auth]);
   
   // Fetch matchdays with filters
-  const { data: matchdaysData, isLoading, error, refetch } = useMatchdays({
+  const { data: matchdaysData, isLoading, error } = useMatchdays({
     status: statusFilter,
     isPublic: true,
     page: 1,
@@ -133,9 +133,6 @@ export default function MatchdaysPage() {
           </p>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={() => refetch()}>
-            Refresh
-          </Button>
           {user && (
             <Button onClick={() => setShowForm(true)}>
               Create Matchday

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,7 +47,7 @@ export default function HomePage() {
   }, [supabase.auth]);
   
   // Fetch matchdays with filters
-  const { data: matchdaysData, isLoading, error, refetch } = useMatchdays({
+  const { data: matchdaysData, isLoading, error } = useMatchdays({
     status: statusFilter,
     isPublic: true,
     page: 1,
@@ -125,9 +125,6 @@ export default function HomePage() {
           </p>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={() => refetch()}>
-            Refresh
-          </Button>
           {user && (
             <Button onClick={() => setShowForm(true)}>
               Create Matchday


### PR DESCRIPTION
Completes task 19: Remove the refresh button from both home page and matchdays page UI. The button was located in the top-right corner next to the 'Create Matchday' button.

Changes:
- Removed refresh button from home page (src/app/page.tsx)
- Removed refresh button from matchdays page (src/app/matchdays/page.tsx)
- Cleaned up refetch function usage in both components
- Updated task 19 status to completed

The layout remains clean with only the 'Create Matchday' button for authenticated users.