### PR TITLE
Remove activity tab from matchday view

### DIFF
--- a/src/app/matchdays/[id]/page.tsx
+++ b/src/app/matchdays/[id]/page.tsx
@@ -17,7 +17,7 @@ interface MatchdayDetailPageProps {
   }>;
 }
 
-type TabType = 'overview' | 'teams' | 'games' | 'stats' | 'activity';
+type TabType = 'overview' | 'teams' | 'games' | 'stats';
 
 interface CollapsibleSectionProps {
   title: string;
@@ -235,7 +235,6 @@ export default function MatchdayDetailPage({ params }: MatchdayDetailPageProps) 
     { id: 'teams', label: 'Teams' },
     { id: 'games', label: 'Games' },
     { id: 'stats', label: 'Stats', disabled: true },
-    { id: 'activity', label: 'Activity', disabled: true },
   ];
 
   const renderTabContent = () => {
@@ -344,12 +343,6 @@ export default function MatchdayDetailPage({ params }: MatchdayDetailPageProps) 
         return (
           <div className="text-center py-8">
             <p className="text-muted-foreground">Statistics coming soon...</p>
-          </div>
-        );
-      case 'activity':
-        return (
-          <div className="text-center py-8">
-            <p className="text-muted-foreground">Activity log coming soon...</p>
           </div>
         );
       default:


### PR DESCRIPTION
## Summary
- remove the placeholder Activity tab from the matchday detail view
- clean up the tab type definition and rendering logic accordingly

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1898944c0832496fa5d1e094dd74a