### PR TITLE
feat: add profile settings management

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema';
+import { requireAuth } from '@/lib/auth-guards';
+import { ProfileSettingsSchema } from '@/lib/validations/user';
+import { createClient } from '@/lib/supabase/server';
+
+const profileSelection = {
+  id: users.id,
+  email: users.email,
+  displayName: users.displayName,
+  fullName: users.fullName,
+  avatarUrl: users.avatarUrl,
+  birthDate: users.birthDate,
+  gender: users.gender,
+  createdAt: users.createdAt,
+  updatedAt: users.updatedAt,
+};
+
+export async function GET() {
+  try {
+    const { user } = await requireAuth();
+
+    const [profile] = await db
+      .select(profileSelection)
+      .from(users)
+      .where(eq(users.id, user.id))
+      .limit(1);
+
+    if (!profile) {
+      return NextResponse.json(
+        { error: 'User profile not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ data: profile });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'UNAUTHORIZED') {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    console.error('Failed to load profile:', error);
+    return NextResponse.json(
+      { error: 'Failed to load profile' },
+      { status: (error as { status?: number })?.status || 500 }
+    );
+  }
+}
+
+export async function PATCH(request: Request) {
+  try {
+    const { user } = await requireAuth();
+    const body = await request.json();
+    const payload = ProfileSettingsSchema.parse(body);
+
+    const now = new Date();
+
+    const [updatedProfile] = await db
+      .update(users)
+      .set({
+        displayName: payload.displayName,
+        birthDate: payload.birthDate ?? null,
+        gender: payload.gender ?? null,
+        updatedAt: now,
+        updatedBy: user.id,
+      })
+      .where(eq(users.id, user.id))
+      .returning(profileSelection);
+
+    if (!updatedProfile) {
+      return NextResponse.json(
+        { error: 'User profile not found' },
+        { status: 404 }
+      );
+    }
+
+    try {
+      const supabase = await createClient();
+      if (supabase && 'auth' in supabase && typeof supabase.auth?.updateUser === 'function') {
+        const { error: metadataError } = await supabase.auth.updateUser({
+          data: {
+            display_name: payload.displayName,
+          },
+        });
+
+        if (metadataError) {
+          console.error('Failed to update Supabase metadata:', metadataError);
+        }
+      }
+    } catch (metadataError) {
+      console.error('Failed to sync Supabase metadata:', metadataError);
+    }
+
+    return NextResponse.json({
+      data: updatedProfile,
+      message: 'Profile updated successfully',
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'UNAUTHORIZED') {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    if (error instanceof Error && error.name === 'ZodError') {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 400 }
+      );
+    }
+
+    console.error('Failed to update profile:', error);
+    return NextResponse.json(
+      { error: 'Failed to update profile' },
+      { status: (error as { status?: number })?.status || 500 }
+    );
+  }
+}

--- a/src/app/profile/settings/page.tsx
+++ b/src/app/profile/settings/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import * as React from 'react';
+import { useEffect } from 'react';
+import { Form, useZodForm } from '@/components/forms/Form';
+import { SelectField, SubmitButton, TextField } from '@/components/forms/fields';
+import { useProfile, useUpdateProfile } from '@/lib/hooks/use-profile';
+import {
+  PROFILE_GENDER_OPTIONS,
+  ProfileSettingsSchema,
+  type ProfileSettings,
+} from '@/lib/validations/user';
+
+export default function ProfileSettingsPage() {
+  const profileQuery = useProfile();
+  const updateProfile = useUpdateProfile();
+
+  const methods = useZodForm(ProfileSettingsSchema, {
+    defaultValues: {
+      displayName: '',
+      birthDate: undefined,
+      gender: undefined,
+    },
+  });
+
+  const profile = profileQuery.data?.data;
+
+  useEffect(() => {
+    if (profile) {
+      methods.reset({
+        displayName:
+          profile.displayName ||
+          profile.fullName ||
+          profile.email?.split?.('@')?.[0] ||
+          '',
+        birthDate: profile.birthDate ?? undefined,
+        gender: (profile.gender ?? undefined) as ProfileSettings['gender'],
+      });
+    }
+  }, [profile, methods]);
+
+  const handleSubmit = async (values: ProfileSettings) => {
+    try {
+      await updateProfile.mutateAsync(values);
+    } catch {
+      // Errors are surfaced via the mutation hook's toast handlers
+    }
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Profile Settings</h1>
+        <p className="text-sm text-muted-foreground">
+          Manage how your profile information appears across the app.
+        </p>
+      </div>
+
+      <Form methods={methods} onSubmit={handleSubmit} className="space-y-6">
+        <fieldset
+          className="space-y-6"
+          disabled={profileQuery.isLoading || updateProfile.isPending}
+        >
+          <TextField
+            name="displayName"
+            label="Display Name"
+            placeholder="e.g. Alex Morgan"
+            required
+          />
+
+          <TextField
+            name="birthDate"
+            label="Birth Date"
+            type="date"
+          />
+
+          <SelectField
+            name="gender"
+            label="Gender"
+            placeholder="Select gender (optional)"
+            options={PROFILE_GENDER_OPTIONS}
+          />
+
+          <SubmitButton pendingLabel="Saving...">
+            Save changes
+          </SubmitButton>
+        </fieldset>
+      </Form>
+    </div>
+  );
+}

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -5,11 +5,14 @@ import Link from "next/link";
 import { useAuth } from "@/components/auth/AuthGuard";
 import { Button } from "@/components/ui/button";
 import { ChevronDown, User, Settings, LogOut } from "lucide-react";
+import { useProfile } from "@/lib/hooks/use-profile";
 
 export function UserMenu() {
   const { user, loading, signOut } = useAuth();
   const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
   const dropdownRef = React.useRef<HTMLDivElement>(null);
+  const profileQuery = useProfile({ enabled: !!user });
+  const profile = profileQuery.data?.data;
 
   // Handle click outside to close dropdown
   React.useEffect(() => {
@@ -53,9 +56,13 @@ export function UserMenu() {
   }
 
   if (user) {
-    const displayName = user.user_metadata?.full_name || 
-                       user.email?.split('@')[0] || 
-                       'User';
+    const displayName =
+      user.user_metadata?.display_name ||
+      profile?.displayName ||
+      user.user_metadata?.full_name ||
+      profile?.fullName ||
+      user.email?.split('@')[0] ||
+      'User';
     
     return (
       <div className="relative" ref={dropdownRef}>

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -26,6 +26,9 @@ export const users = pgTable('users', {
   email: text('email').notNull().unique(),
   fullName: text('full_name'),
   avatarUrl: text('avatar_url'),
+  displayName: text('display_name'),
+  birthDate: text('birth_date'),
+  gender: text('gender'),
   isActive: boolean('is_active').default(true).notNull(),
 }, (table) => ({
   emailIdx: index('users_email_idx').on(table.email),

--- a/src/lib/hooks/use-profile.ts
+++ b/src/lib/hooks/use-profile.ts
@@ -50,7 +50,7 @@ async function updateProfile(data: ProfileSettings): Promise<ProfileResponse> {
 }
 
 export function useProfile(options?: { enabled?: boolean }) {
-  return useQuery({
+  return useQuery<ProfileResponse, Error>({
     queryKey: ['profile'],
     queryFn: fetchProfile,
     enabled: options?.enabled ?? true,
@@ -64,7 +64,7 @@ export function useProfile(options?: { enabled?: boolean }) {
 export function useUpdateProfile() {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  return useMutation<ProfileResponse, Error, ProfileSettings>({
     mutationFn: updateProfile,
     onSuccess: (data) => {
       queryClient.setQueryData(['profile'], data);

--- a/src/lib/hooks/use-profile.ts
+++ b/src/lib/hooks/use-profile.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import type { ProfileSettings } from '@/lib/validations/user';
+
+interface Profile {
+  id: string;
+  email: string;
+  displayName: string | null;
+  fullName: string | null;
+  avatarUrl: string | null;
+  birthDate: string | null;
+  gender: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ProfileResponse {
+  data: Profile;
+  message?: string;
+}
+
+async function fetchProfile(): Promise<ProfileResponse> {
+  const response = await fetch('/api/profile');
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || 'Failed to load profile');
+  }
+
+  return response.json() as Promise<ProfileResponse>;
+}
+
+async function updateProfile(data: ProfileSettings): Promise<ProfileResponse> {
+  const response = await fetch('/api/profile', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || 'Failed to update profile');
+  }
+
+  return response.json() as Promise<ProfileResponse>;
+}
+
+export function useProfile(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: ['profile'],
+    queryFn: fetchProfile,
+    enabled: options?.enabled ?? true,
+    staleTime: 5 * 60 * 1000,
+    onError: (error: Error) => {
+      toast.error(error.message);
+    },
+  });
+}
+
+export function useUpdateProfile() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateProfile,
+    onSuccess: (data) => {
+      queryClient.setQueryData(['profile'], data);
+      toast.success(data.message || 'Profile updated successfully');
+    },
+    onError: (error: Error) => {
+      toast.error(error.message);
+    },
+  });
+}

--- a/src/lib/validations/user.ts
+++ b/src/lib/validations/user.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+const GenderEnum = z.enum(['male', 'female', 'non_binary', 'other', 'prefer_not_to_say']);
+
+const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+export const ProfileSettingsSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .min(2, 'Display name must be at least 2 characters')
+    .max(100, 'Display name must be less than 100 characters'),
+  birthDate: z
+    .preprocess(
+      (value) => (value === '' || value === null ? undefined : value),
+      z
+        .string()
+        .regex(isoDateRegex, 'Birth date must be a valid ISO date (YYYY-MM-DD)')
+        .optional()
+    ),
+  gender: z
+    .preprocess(
+      (value) => (value === '' || value === null ? undefined : value),
+      GenderEnum.optional()
+    ),
+});
+
+export type ProfileSettings = z.infer<typeof ProfileSettingsSchema>;
+export type ProfileGender = z.infer<typeof GenderEnum>;
+
+export const PROFILE_GENDER_OPTIONS: Array<{ value: ProfileGender; label: string }> = [
+  { value: 'male', label: 'Male' },
+  { value: 'female', label: 'Female' },
+  { value: 'non_binary', label: 'Non-binary' },
+  { value: 'other', label: 'Other' },
+  { value: 'prefer_not_to_say', label: 'Prefer not to say' },
+];


### PR DESCRIPTION
## Summary
- add a profile settings validation schema and react-query hooks for loading and updating the current profile
- implement the /api/profile GET and PATCH handlers to persist settings and sync the Supabase display name
- build the profile settings form UI and surface the preferred display name in the user menu dropdown

## Testing
- npm run lint *(fails: existing lint issues across the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e52d3bfc648324b866a5f5cde83c05