### PR TITLE
Fix: Add autoFocus prop to TextField component

### DIFF
--- a/src/components/forms/fields.tsx
+++ b/src/components/forms/fields.tsx
@@ -13,9 +13,10 @@ interface TextFieldProps {
   multiline?: boolean;
   rows?: number;
   step?: string;
+  autoFocus?: boolean;
 }
 
-export function TextField({ name, label, type = "text", placeholder, required, multiline, rows = 3, step }: TextFieldProps) {
+export function TextField({ name, label, type = "text", placeholder, required, multiline, rows = 3, step, autoFocus }: TextFieldProps) {
   const { register, formState: { errors } } = useFormContext();
   const error = (errors as any)?.[name]?.message as string | undefined;
   
@@ -25,6 +26,7 @@ export function TextField({ name, label, type = "text", placeholder, required, m
     className: "w-full rounded-md border border-input bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
     "aria-invalid": !!error,
     "aria-describedby": error ? `${name}-error` : undefined,
+    autoFocus,
     ...register(name),
   };
   


### PR DESCRIPTION
Fixes TypeScript compilation error in Vercel deployment.

## Problem
The PlayerForm component was passing an  prop to the TextField component, but the TextField's TypeScript interface didn't include this property, causing a build failure:

type is a shell builtin

## Solution
- Added  to the  interface
- Updated the TextField component to accept and apply the autoFocus prop
- The prop is applied to both input and textarea elements via commonProps

## Testing
- ✅ Reproduced the original build error locally
- ✅ Verified the fix resolves the TypeScript error
- ✅ Build now completes successfully
- ✅ No linting errors introduced

This maintains backward compatibility and improves UX for the quick-add player functionality.