### PR TITLE
Redesign matchday detail page with floating tabs and breadcrumb navigation

### DIFF
--- a/.cursor/plans/matchday-page-redesign-8e15f74f.plan.md
+++ b/.cursor/plans/matchday-page-redesign-8e15f74f.plan.md
@@ -1,0 +1,89 @@
+<!-- 8e15f74f-4cb4-4615-9eec-2d35042f972d dce30fc8-2907-488b-a484-357acb674e45 -->
+# Matchday Page Redesign
+
+## Overview
+
+Transform the matchday detail page with improved navigation, cleaner layout, sticky bottom tabs, and inline editing capabilities.
+
+## Key Changes
+
+### 1. Header & Breadcrumb Navigation
+
+**File:** `src/components/layout/AppShell.tsx`
+
+- Update `getPageTitle()` to detect matchday detail pages (`/matchdays/[id]`)
+- Return breadcrumb-style title: "Matchdays → [Date]" with clickable navigation
+- Add three-dot menu (DropdownMenu from shadcn) next to breadcrumb for delete action
+- Remove the back button and title/subtitle from the page content
+
+### 2. Install shadcn Tabs Component
+
+**Command:** `npx shadcn@latest add tabs`
+
+- Install the tabs component for the sticky bottom navigation
+
+### 3. Sticky Bottom Tabs
+
+**File:** `src/app/matchdays/[id]/[[...tab]]/page.tsx`
+
+- Replace current border-bottom tabs (lines 499-536) with shadcn Tabs component
+- Position tabs fixed at bottom: `fixed bottom-0 left-0 right-0 z-50`
+- Three tabs only: Overview, Games, Teams (remove Stats tab)
+- Style with backdrop blur and border-top for floating effect
+
+### 4. Overview Tab Redesign
+
+**File:** `src/app/matchdays/[id]/[[...tab]]/page.tsx`
+
+- Keep collapsible "Matchday Information" section with pencil icon for inline editing
+- Keep collapsible "Game Rules" section with pencil icon for inline editing
+- Add icons to Information fields:
+- Calendar icon for Date & Time
+- MapPin icon for Location
+- Users icon for Team Size
+- Hash icon for Number of Teams
+- Remove Status chip from Information section
+- Move Stats tab content (lines 378-447) into Overview tab below collapsibles
+- Include summary cards, StandingsTable, and TopScorerTable
+
+### 5. Inline Editing State Management
+
+**File:** `src/app/matchdays/[id]/[[...tab]]/page.tsx`
+
+- Add state: `isEditingInfo` and `isEditingRules` (separate from current `isEditing`)
+- When pencil clicked, convert display fields to form inputs inline
+- Replace pencil with checkmark icon when in edit mode
+- On checkmark click, call `updateMutation.mutateAsync()` and revert to display mode
+- Use existing `MatchdayUpdateSchema` for validation
+
+### 6. Three-Dot Delete Menu
+
+**File:** `src/components/layout/AppShell.tsx`
+
+- Import DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger
+- Add MoreVertical icon (three dots) next to breadcrumb
+- Menu item: "Delete Matchday" with Trash2 icon
+- Call existing `handleDeleteMatchday` logic with confirm dialog
+- Only show menu when user is authenticated and on matchday detail page
+
+### 7. Content Padding Adjustment
+
+**File:** `src/app/matchdays/[id]/[[...tab]]/page.tsx`
+
+- Add bottom padding to content area: `pb-24` to account for fixed bottom tabs
+- Remove header section (lines 456-496) - now handled by AppShell
+- Remove back button, title, and subtitle
+
+## Files to Modify
+
+1. `src/components/layout/AppShell.tsx` - Breadcrumb navigation + three-dot menu
+2. `src/app/matchdays/[id]/[[...tab]]/page.tsx` - Main redesign: tabs, inline editing, layout
+3. Install shadcn tabs component
+
+## Implementation Notes
+
+- Use existing hooks: `useMatchday`, `useUpdateMatchday`, `useDeleteMatchday`, `useMatchdayStats`
+- Preserve all existing functionality (team management, game management)
+- Maintain accessibility with proper ARIA labels
+- Keep confirm dialog for delete action
+- Reuse `CollapsibleSection` component for Information and Rules

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@react-email/render": "^1.2.3",
         "@supabase/ssr": "^0.7.0",
@@ -5767,6 +5768,36 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-email/render": "^1.2.3",
     "@supabase/ssr": "^0.7.0",

--- a/src/components/forms/fields.tsx
+++ b/src/components/forms/fields.tsx
@@ -109,6 +109,45 @@ export function SelectField({ name, label, placeholder, required, options, child
   );
 }
 
+interface NumberFieldProps {
+  name: string;
+  label: string;
+  placeholder?: string;
+  required?: boolean;
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+export function NumberField({ name, label, placeholder, required, min, max, step }: NumberFieldProps) {
+  const { register, formState: { errors } } = useFormContext();
+  const error = (errors as any)?.[name]?.message as string | undefined;
+  
+  return (
+    <div className="space-y-1">
+      <label className="text-sm font-medium" htmlFor={name}>
+        {label}
+        {required && <span className="text-red-500 ml-1">*</span>}
+      </label>
+      <input
+        id={name}
+        type="number"
+        placeholder={placeholder}
+        min={min}
+        max={max}
+        step={step}
+        className="w-full rounded-md border border-input bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        aria-invalid={!!error}
+        aria-describedby={error ? `${name}-error` : undefined}
+        {...register(name, { valueAsNumber: true })}
+      />
+      {error ? (
+        <p id={`${name}-error`} className="text-sm text-red-600">{error}</p>
+      ) : null}
+    </div>
+  );
+}
+
 export function SubmitButton({ pendingLabel = "Submitting...", children, ...props }: React.ComponentProps<typeof Button> & { pendingLabel?: string }) {
   const { formState } = useFormContext();
   return (

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import React from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import Link from "next/link";
 import { AppSidebar } from "./AppSidebar";
 import {
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbList,
   BreadcrumbPage,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -15,19 +18,159 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { MoreVertical, Trash2 } from "lucide-react";
+import { useMatchday, useDeleteMatchday } from "@/lib/hooks/use-matchdays";
+import { useConfirm } from "@/lib/hooks/use-dialogs";
+import { getMatchdayDisplayName } from "@/lib/matchday-display";
+import { createClient } from "@/lib/supabase/client";
+import type { User, AuthChangeEvent, Session } from "@supabase/supabase-js";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const router = useRouter();
+  const [user, setUser] = React.useState<User | null>(null);
+  const confirm = useConfirm();
+  const supabase = createClient();
+  
+  // Extract matchday ID from pathname
+  const matchdayIdMatch = pathname.match(/^\/matchdays\/([^\/]+)/);
+  const matchdayId = matchdayIdMatch ? matchdayIdMatch[1] : null;
+  const isMatchdayDetailPage = matchdayId && matchdayId !== 'undefined';
+  
+  // Fetch matchday data if on detail page
+  const { data: matchdayData } = useMatchday(isMatchdayDetailPage ? matchdayId : '');
+  const deleteMutation = useDeleteMatchday();
+  
+  // Get current user
+  React.useEffect(() => {
+    const getUser = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      setUser(user);
+    };
+    getUser();
+    
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      (_event: AuthChangeEvent, session: Session | null) => {
+        setUser(session?.user ?? null);
+      }
+    );
+    
+    return () => subscription.unsubscribe();
+  }, [supabase.auth]);
+
+  // Handle delete matchday
+  const handleDeleteMatchday = async () => {
+    if (!matchdayData || !matchdayId) return;
+    
+    try {
+      const confirmed = await confirm({
+        title: 'Delete Matchday',
+        message: `Are you sure you want to delete "${matchdayData.data.name}"? This action cannot be undone.`,
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        variant: 'default',
+      });
+      
+      if (confirmed) {
+        await deleteMutation.mutateAsync(matchdayId);
+        router.push('/matchdays');
+      }
+    } catch (error) {
+      console.log('Delete cancelled');
+    }
+  };
 
   // Derive page title from pathname
   const getPageTitle = () => {
     if (pathname === "/overview" || pathname === "/") return "Overview";
     if (pathname === "/players") return "Players";
     if (pathname === "/stats") return "Stats";
-    if (pathname.startsWith("/matchdays")) return "Matchdays";
     if (pathname.startsWith("/groups/") && pathname.endsWith("/settings")) return "Group Settings";
     if (pathname === "/profile") return "Profile";
     return "Dashboard";
+  };
+  
+  const renderBreadcrumb = () => {
+    // Matchday detail page - show breadcrumb with navigation
+    if (isMatchdayDetailPage && matchdayData) {
+      const matchdayName = getMatchdayDisplayName(
+        matchdayData.data.scheduledAt,
+        matchdayData.data.location
+      );
+      
+      return (
+        <div className="flex items-center gap-2">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link href="/matchdays">Matchdays</Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>{matchdayName}</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+          
+          {user && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label="Matchday options"
+                >
+                  <MoreVertical className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onClick={handleDeleteMatchday}
+                  disabled={deleteMutation.isPending}
+                  className="text-red-600 focus:text-red-600"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete Matchday
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+      );
+    }
+    
+    // Regular page - show simple title
+    if (pathname.startsWith("/matchdays")) {
+      return (
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbPage>Matchdays</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      );
+    }
+    
+    return (
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage>{getPageTitle()}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+    );
   };
 
   return (
@@ -44,13 +187,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           <div className="flex items-center gap-2 px-4">
             <SidebarTrigger className="-ml-1" />
             <Separator orientation="vertical" className="mr-2 h-4" />
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem>
-                  <BreadcrumbPage>{getPageTitle()}</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
+            {renderBreadcrumb()}
           </div>
         </header>
         <main id="main-content" className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/lib/matchday-display.ts
+++ b/src/lib/matchday-display.ts
@@ -1,6 +1,6 @@
 /**
  * Generate a display name for a matchday based on date and optional location
- * Format: "29/9 Matchday" or "29/9 at The Yarkon"
+ * Format: "Wednesday 8/10" or "Wednesday 29/9"
  */
 export function getMatchdayDisplayName(scheduledAt: Date | string, location?: string | null): string {
   const date = typeof scheduledAt === 'string' ? new Date(scheduledAt) : scheduledAt;
@@ -11,12 +11,9 @@ export function getMatchdayDisplayName(scheduledAt: Date | string, location?: st
   
   const day = date.getDate();
   const month = date.getMonth() + 1;
+  const weekday = date.toLocaleDateString('en-US', { weekday: 'long' });
   
-  if (location && location.trim()) {
-    return `${day}/${month} at ${location.trim()}`;
-  }
-  
-  return `${day}/${month} Matchday`;
+  return `${weekday} ${day}/${month}`;
 }
 
 /**

--- a/src/lib/validations/matchday.ts
+++ b/src/lib/validations/matchday.ts
@@ -55,6 +55,7 @@ export const MatchdayUpdateSchema = z.object({
   teamSize: z.coerce.number().int().min(3).max(15).optional(),
   numberOfTeams: z.coerce.number().int().min(2).max(20).optional(),
   status: z.enum(['upcoming', 'active', 'completed', 'cancelled']).optional(),
+  rules: RulesSnapshotSchema.optional(),
 });
 
 // Schema for query parameters


### PR DESCRIPTION
## Changes

### Header & Navigation
- Added breadcrumb navigation showing 'Matchdays → Wednesday 8/10' with clickable back link
- Added three-dot menu in header with delete matchday option
- Matchday name format changed to show day of week (e.g., 'Wednesday 8/10')

### Bottom Tabs
- Implemented floating, rounded tabs at the bottom with glassmorphism effect
- Tabs are now transparent with blur effect and subtle blue border
- Three tabs: Overview, Games, Teams (Stats moved to Overview)
- Active tab uses semi-transparent primary color
- Tabs have proper spacing from screen edges with visible content around them

### Overview Tab
- Added inline editing for Information and Rules sections
- Pencil icons toggle edit mode, checkmark saves changes
- Added icons to Information fields:
  - Calendar for Date & Time
  - MapPin for Location  
  - Users for Team Size
  - Hash for Number of Teams
- Removed status chip
- Integrated matchday statistics (summary cards, standings, top scorers) into Overview

### Technical Changes
- Added NumberField component for form inputs
- Updated MatchdayUpdateSchema to support rules editing
- Installed shadcn tabs component
- Removed redundant header elements from page content

## Files Modified
- `src/components/layout/AppShell.tsx`
- `src/app/matchdays/[id]/[[...tab]]/page.tsx`
- `src/components/forms/fields.tsx`
- `src/lib/validations/matchday.ts`
- `src/lib/matchday-display.ts`
- `src/components/ui/tabs.tsx` (new)

## Screenshots
See screenshots in PR description for visual changes.